### PR TITLE
yaml.md: make better example of references

### DIFF
--- a/yaml.md
+++ b/yaml.md
@@ -61,10 +61,6 @@ child:
 ### Reference content
 
 ```yaml
-values: &ref
-  - These values
-  - will be reused below
-  
-other_values:
-  <<: *ref
+key1: &ref 42
+key2: *ref
 ```

--- a/yaml.md
+++ b/yaml.md
@@ -61,6 +61,11 @@ child:
 ### Reference content
 
 ```yaml
-key1: &ref 42
-key2: *ref
+simple_value: &refv 42
+simple_reuse: *refv
+
+list_value: &refl
+  - will be
+  - reused below
+list_reuse: *refl
 ```


### PR DESCRIPTION
There already was an example for referencing defaults. Replace with an example for simple values instead.

Plus, the example had invalid syntax in it…